### PR TITLE
Adding action `set` in order to use it in acceptance testing

### DIFF
--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -64,6 +64,12 @@ export default Ember.Component.extend({
       });
     });
 
+    slider.on('set', () => {
+      run(this, function () {
+        this.sendAction('set', this.get('slider').get());
+      });
+    });
+
     if (!isEmpty(this.get('slide'))) {
       slider.on('slide', () => {
         run(this, function () {


### PR DESCRIPTION
I'm trying to write some acceptance tests in an ember app, and is hard to emule user sliding the slider. I found in their own tests that they use the method `set`, to set values on the component. It works, but the component doesn't trigger the `change` neither the `slide` event. We can see in this image that it trigger the `set` and `update` event. 
![noUiSlider events]
(https://s3.amazonaws.com/awesomescreenshot/upload/161821/166862/98ce53b9-39ec-423d-742a-56a9884e907b.png?AWSAccessKeyId=AKIAJSCJQ2NM3XLFPVKA&Expires=1449214805&Signature=gHVZbYRXt3WR4BCnIgNn0IDJsOY%3D)
So I'm binding the `set` event to the action `set`.
This is and example of how I'm testing:
```javascript
const priceSlider = find('.noUi-target:first');
priceSlider[0].noUiSlider.set([500, 1090]);
click('[data-test-selector="filter-button"]');
andThen(() => {
  server.get('accommodations', (db, request) => {
    assert.equal(request.queryParams.minPrice, 500, 'minPrice should be equal to 500');
    assert.equal(request.queryParams.maxPrice, 1090, 'maxPrice should be equal to 1090');
  }
});
```
So this set will trigger the action `set` and with this anyone can update the max and min, and assert the values in their tests ;)
