### PR TITLE
Fix loading in engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,7 @@ module.exports = {
     if(!process.env.EMBER_CLI_FASTBOOT) {
 
       // Fix for loading it in addons/engines
-      if (typeof app.import !== 'function' && app.app) {
-        app = app.app;
-      }
+      app = recursivelyFindApp(app);
 
       app.import({
         development: app.bowerDirectory + '/nouislider/distribute/nouislider.js',
@@ -25,3 +23,10 @@ module.exports = {
     }
   }
 };
+
+function recursivelyFindApp(app) {
+  if (app.import) {
+    return app;
+  }
+  return recursivelyFindApp(app.app);
+}

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     if(!process.env.EMBER_CLI_FASTBOOT) {
+
+      // Fix for loading it in addons/engines
+      if (typeof app.import !== 'function' && app.app) {
+        app = app.app;
+      }
+
       app.import({
         development: app.bowerDirectory + '/nouislider/distribute/nouislider.js',
         production:  app.bowerDirectory + '/nouislider/distribute/nouislider.min.js'

--- a/index.js
+++ b/index.js
@@ -7,15 +7,18 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     if (!process.env.EMBER_CLI_FASTBOOT) {
+      // In nested addons, app.bowerDirectory might not be available
       var bowerDirectory = app.bowerDirectory || 'bower_components';
+      // In ember-cli < 2.7, this.import is not available, so fall back to use app.import
+      var importShim = typeof this.import !== 'undefined' ? this : app;
 
-      this.import({
+      importShim.import({
         development: bowerDirectory + '/nouislider/distribute/nouislider.js',
         production: bowerDirectory + '/nouislider/distribute/nouislider.min.js'
       });
-      this.import(bowerDirectory + '/nouislider/distribute/nouislider.min.css');
+      importShim.import(bowerDirectory + '/nouislider/distribute/nouislider.min.css');
 
-      this.import('vendor/nouislider/shim.js', {
+      importShim.import('vendor/nouislider/shim.js', {
         exports: { 'noUiSlider': ['default'] }
       });
     }

--- a/index.js
+++ b/index.js
@@ -6,27 +6,18 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-    if(!process.env.EMBER_CLI_FASTBOOT) {
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      var bowerDirectory = app.bowerDirectory || 'bower_components';
 
-      // Fix for loading it in addons/engines
-      app = recursivelyFindApp(app);
-
-      app.import({
-        development: app.bowerDirectory + '/nouislider/distribute/nouislider.js',
-        production:  app.bowerDirectory + '/nouislider/distribute/nouislider.min.js'
+      this.import({
+        development: bowerDirectory + '/nouislider/distribute/nouislider.js',
+        production: bowerDirectory + '/nouislider/distribute/nouislider.min.js'
       });
-      app.import(app.bowerDirectory + '/nouislider/distribute/nouislider.min.css');
+      this.import(bowerDirectory + '/nouislider/distribute/nouislider.min.css');
 
-      app.import('vendor/nouislider/shim.js', {
+      this.import('vendor/nouislider/shim.js', {
         exports: { 'noUiSlider': ['default'] }
       });
     }
   }
 };
-
-function recursivelyFindApp(app) {
-  if (app.import) {
-    return app;
-  }
-  return recursivelyFindApp(app.app);
-}


### PR DESCRIPTION
When used in an engine, `app.import` was not available and failed. This PR fixes this and makes it possible to use ember-cli-nouislider it in engines.