### PR TITLE
Add missing "tooltips" option

### DIFF
--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -22,6 +22,7 @@ export default Ember.Component.extend({
   orientation:  'horizontal',
   direction:    'ltr',
   behaviour:    'tap',
+  tooltips:     false,
 
   min: 0,
   max: 100,
@@ -50,7 +51,7 @@ export default Ember.Component.extend({
       'limit', 'range', 'connect',
       'orientation', 'direction',
       'behaviour', 'animate', 'snap',
-      'pips', 'format'
+      'pips', 'format', 'tooltips'
     );
     let sliderEvents = Ember.A(['change', 'set', 'slide', 'update', 'start', 'end']);
 


### PR DESCRIPTION
Hi @kennethkalmer,

I just came across a scenario in which I need to use tooltips on handlers, and I saw, that there is no `tooltips` option in this wrapper. So I decided to add it.

Now I can set in my component
```
tooltips: [
    { to: (num) => Math.floor(num) },
],
```
and pass it to `range-slider` like so:
```
{{range-slider
    start=start
    range=range
    tooltips=tooltips
    on-change=(action 'onChange')
}}
```

Hope you'll find it useful too and release it soon :)