### PR TITLE
Now we first check if an element has an uislider already associated. …

### DIFF
--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -99,7 +99,6 @@ export default Ember.Component.extend({
         });
       }
     });
-
   }),
 
   update: on('didUpdateAttrs', function() {

--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -26,7 +26,6 @@ export default Ember.Component.extend({
   behaviour:    'tap',
   tooltips:     false,
 
-
   min: 0,
   max: 100,
 


### PR DESCRIPTION
Now we first check if an element has an uislider already associated. If it's the case we destroy that slider first.

Also we moved the assigments in the didInsertElement hook to next sync queue to avoid deprecation warnings.