### PR TITLE
Fix incorrect behaviour with negative ranges

### DIFF
--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -37,7 +37,7 @@ export default Ember.Component.extend({
   }),
 
   formatTo(value) { return value; },
-  formatFrom(value) { return value; },
+  formatFrom(value) { return +value; },
 
   format: computed('formatTo', 'formatFrom', function() {
     return {


### PR DESCRIPTION
This apply the fix in issue https://github.com/kennethkalmer/ember-cli-nouislider/issues/24 that allow to use negative numbers without the slider jumping back to minimal value