### PR TITLE
Removed deprecated sendAction

### DIFF
--- a/addon/components/range-slider.js
+++ b/addon/components/range-slider.js
@@ -90,7 +90,7 @@ export default Component.extend({
         slider.on(event, () => {
           run(this, function() {
             let val = this.get("slider").get();
-            this.sendAction(`on-${event}`, val);
+            this[`on-${event}`](val);
           });
         });
       }


### PR DESCRIPTION
From Ember 3.4 onwards, `sendAction` has been deprecated. I've replaced it by a closure action to solve it.