### PR TITLE
ci: auto-approve PRs on LGTM comment

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,32 @@
+name: Auto-approve PR on LGTM comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  auto-approve:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'kennethkalmer' &&
+      contains(github.event.comment.body, 'LGTM')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE'
+            });


### PR DESCRIPTION
Adds `.github/workflows/auto-approve.yml`. Approves a PR when **kennethkalmer** comments `LGTM`.

## How it works
- Triggers on `issue_comment` (created)
- Guard: comment author is `kennethkalmer`, body contains `LGTM`, and the issue is a PR
- Mints a GitHub App token via `actions/create-github-app-token@v2`
- Approves the PR through `github-script` using the app token

## Required setup
Add repo secrets from the companion GitHub App:
- `APP_ID`
- `APP_PRIVATE_KEY`

The app identity does the approval, enabling self-approving PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)