### PR TITLE
ci: publish to npm via Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+# OIDC + read-only repo contents = enough for npm Trusted Publishers.
+# No NPM_TOKEN secret is used; npm exchanges the GitHub OIDC token for a
+# short-lived publish credential. The package must be configured for a
+# trusted publisher on npmjs.com (Settings → Trusted Publishers) pointing
+# at this repository + workflow file before the first run.
+#
+# See https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    name: Publish ember-cli-nouislider
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build addon
+        run: pnpm --filter ember-cli-nouislider build
+
+      - name: Publish to npm with provenance
+        working-directory: ember-cli-nouislider
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so a published GitHub release
publishes `ember-cli-nouislider` to npm using the
[Trusted Publishers / OIDC flow](https://docs.npmjs.com/trusted-publishers).
No `NPM_TOKEN` secret is involved.

The workflow:

- Triggers on `release: published` and `workflow_dispatch`.
- Sets `id-token: write` permission so GitHub mints an OIDC token.
- Builds the addon (`pnpm --filter ember-cli-nouislider build`).
- Runs `npm publish --provenance --access public` inside
  `ember-cli-nouislider/`, which exchanges the OIDC token for a
  short-lived publish credential and stamps a sigstore provenance
  attestation on the release.

## Manual npm-side setup (one-time)

On https://www.npmjs.com/package/ember-cli-nouislider → **Settings →
Trusted Publishers**, add a GitHub Actions publisher with:

- Repository: `kennethkalmer/ember-cli-nouislider`
- Workflow filename: `release.yml`
- Environment: *(leave empty)*

After saving, the next published GitHub release will publish to npm
without a token.

## Test plan

- [ ] npm Trusted Publisher configured for `ember-cli-nouislider`.
- [ ] Bump `ember-cli-nouislider/package.json` to a real `2.0.0` (or
  publish a `next` pre-release), push a tag, and cut a GitHub release
  to verify the workflow runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)