### PR TITLE
chore: v2.0.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## master
+## main
 
-## 2.0.0 (unreleased)
+## 2.0.0 2026-06-21
 
 Major rewrite as a v2 Embroider addon.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020
+Copyright (c) 2026
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## Summary

Small bookkeeping after the v2 merge:

- `CHANGELOG.md`: 2.0.0 entry now carries its release date
  (`2026-06-21`) instead of `(unreleased)`.
- `CHANGELOG.md`: top heading `## master` → `## main` to match the
  renamed default branch.
- `LICENSE.md`: copyright year bumped to 2026.

## Test plan

- [ ] Skim diff — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)